### PR TITLE
Bugfix - prevent page reload on token refresh

### DIFF
--- a/import/realm-config/consortia/catenax-central/beta/CX-Central-realm.json
+++ b/import/realm-config/consortia/catenax-central/beta/CX-Central-realm.json
@@ -4,7 +4,7 @@
   "displayName": "Catena-X Central",
   "notBefore": 1660280763,
   "defaultSignatureAlgorithm": "RS256",
-  "revokeRefreshToken": true,
+  "revokeRefreshToken": false,
   "refreshTokenMaxReuse": 1,
   "accessTokenLifespan": 300,
   "accessTokenLifespanForImplicitFlow": 900,

--- a/import/realm-config/consortia/catenax-central/dev/CX-Central-realm.json
+++ b/import/realm-config/consortia/catenax-central/dev/CX-Central-realm.json
@@ -4,7 +4,7 @@
   "displayName": "Catena-X Central",
   "notBefore": 1660280763,
   "defaultSignatureAlgorithm": "RS256",
-  "revokeRefreshToken": true,
+  "revokeRefreshToken": false,
   "refreshTokenMaxReuse": 1,
   "accessTokenLifespan": 300,
   "accessTokenLifespanForImplicitFlow": 900,

--- a/import/realm-config/consortia/catenax-central/int/CX-Central-realm.json
+++ b/import/realm-config/consortia/catenax-central/int/CX-Central-realm.json
@@ -4,7 +4,7 @@
   "displayName": "Catena-X Central",
   "notBefore": 1660280763,
   "defaultSignatureAlgorithm": "RS256",
-  "revokeRefreshToken": true,
+  "revokeRefreshToken": false,
   "refreshTokenMaxReuse": 1,
   "accessTokenLifespan": 300,
   "accessTokenLifespanForImplicitFlow": 900,

--- a/import/realm-config/consortia/catenax-central/pen/CX-Central-realm.json
+++ b/import/realm-config/consortia/catenax-central/pen/CX-Central-realm.json
@@ -4,7 +4,7 @@
   "displayName": "Catena-X Central",
   "notBefore": 1660280763,
   "defaultSignatureAlgorithm": "RS256",
-  "revokeRefreshToken": true,
+  "revokeRefreshToken": false,
   "refreshTokenMaxReuse": 1,
   "accessTokenLifespan": 300,
   "accessTokenLifespanForImplicitFlow": 900,

--- a/import/realm-config/consortia/catenax-central/pre-prod/CX-Central-realm.json
+++ b/import/realm-config/consortia/catenax-central/pre-prod/CX-Central-realm.json
@@ -4,7 +4,7 @@
   "displayName": "Catena-X Central",
   "notBefore": 1660280763,
   "defaultSignatureAlgorithm": "RS256",
-  "revokeRefreshToken": true,
+  "revokeRefreshToken": false,
   "refreshTokenMaxReuse": 1,
   "accessTokenLifespan": 300,
   "accessTokenLifespanForImplicitFlow": 900,

--- a/import/realm-config/generic/catenax-central/CX-Central-realm.json
+++ b/import/realm-config/generic/catenax-central/CX-Central-realm.json
@@ -4,7 +4,7 @@
   "displayName": "Catena-X Central",
   "notBefore": 1660280763,
   "defaultSignatureAlgorithm": "RS256",
-  "revokeRefreshToken": true,
+  "revokeRefreshToken": false,
   "refreshTokenMaxReuse": 1,
   "accessTokenLifespan": 300,
   "accessTokenLifespanForImplicitFlow": 900,

--- a/import/realm-config/generic/catenax-shared/CX-Operator-realm.json
+++ b/import/realm-config/generic/catenax-shared/CX-Operator-realm.json
@@ -4,7 +4,7 @@
   "displayName": "CX-Operator",
   "notBefore": 1660280763,
   "defaultSignatureAlgorithm": "RS256",
-  "revokeRefreshToken": true,
+  "revokeRefreshToken": false,
   "refreshTokenMaxReuse": 1,
   "accessTokenLifespan": 300,
   "accessTokenLifespanForImplicitFlow": 900,


### PR DESCRIPTION
With `revokeRefreshToken` set to `true` frontend apps are unable to run in different browser tabs or windows sharing the same user access token. On the portal frontend this will trigger a page reload on token refresh.
